### PR TITLE
Add compact topbar

### DIFF
--- a/src/renderer/ui/components/topBar/palette/palette.module.scss
+++ b/src/renderer/ui/components/topBar/palette/palette.module.scss
@@ -14,10 +14,11 @@
 }
 
 .palette-tab {
+  position: relative;
   z-index:1;
   display: inline-block;
   font-family: 'Roboto Condensed';
-  padding: 22px 16px;
+  padding: 10px 12px;
   font-size: 16px;
   line-height: 16px;
   background-color: var(--freeter-paletteTabBackground);
@@ -34,10 +35,11 @@
   }
 }
 .palette-section {
+  position: absolute;
   box-sizing: border-box;
   overflow-x: hidden;
   overflow-y:auto;
-  width: 100%;
+  width: 180px;
   z-index:0;
   max-height: 500px;
   display: none;

--- a/src/renderer/ui/components/topBar/topBar.module.scss
+++ b/src/renderer/ui/components/topBar/topBar.module.scss
@@ -8,17 +8,15 @@
   position: fixed;
   z-index: 3;
   background-color: var(--freeter-topBarBackground);
-  border-top: 1px solid var(--freeter-topBarBorder);
   border-bottom: 1px solid var(--freeter-topBarBorder);
   top: 0;
-  left: 0;
   right: 0;
 }
 
 .top-bar-section {
   box-sizing: border-box;
-  padding: 12px;
-  height: 60px;
+  padding: 0 12px;
+  height: 36px;
   display: flex;
   &:not(:last-child) {
     border-right: 1px solid var(--freeter-topBarBorder);

--- a/src/renderer/ui/components/workflowSwitcher/workflowSwitcher.module.scss
+++ b/src/renderer/ui/components/workflowSwitcher/workflowSwitcher.module.scss
@@ -8,9 +8,9 @@
   border-bottom: 1px solid var(--freeter-workflowSwitcherBorder);
   position: fixed;
   z-index: 2;
-  top: 62px;
+  top: 0;
   left: 0;
-  right: 0;
+  right: 275px;
   box-sizing: content-box;
   height: 36px;
 }

--- a/src/renderer/ui/components/worktable/worktable.module.scss
+++ b/src/renderer/ui/components/worktable/worktable.module.scss
@@ -5,7 +5,7 @@
 
 .no-workflows, .worktable {
   position: fixed;
-  top: 99px;
+  top: 37px;
   bottom: 0px;
   left: 0px;
   right: 0px;


### PR DESCRIPTION
The default topbar/toolbar is taking too much space, so I've compacted it:

![Freeter topbar](https://github.com/user-attachments/assets/3688898a-c4e5-4a39-b1b9-02385bb542c5)

Now it looks much better.