### PR TITLE
Add injecting CSS & JS into webpage

### DIFF
--- a/src/renderer/widgets/webpage/settings.tsx
+++ b/src/renderer/widgets/webpage/settings.tsx
@@ -42,6 +42,7 @@ export interface Settings {
   url: string;
   injectedCSS: string;
   injectedJS: string;
+  userAgent: string;
 }
 
 export const createSettingsState: CreateSettingsState<Settings> = (settings) => ({
@@ -51,6 +52,7 @@ export const createSettingsState: CreateSettingsState<Settings> = (settings) => 
   url: typeof settings.url === 'string' ? settings.url : '',
   injectedCSS: typeof settings.injectedCSS === 'string' ? settings.injectedCSS : '',
   injectedJS: typeof settings.injectedJS === 'string' ? settings.injectedJS : '',
+  userAgent: typeof settings.userAgent === 'string' ? settings.userAgent : '',
 })
 
 const debounceUpdate3s = debounce((fn: () => void) => fn(), 3000);
@@ -151,6 +153,14 @@ export function SettingsEditorComp({settings, settingsApi}: SettingsEditorReactC
         moreInfo='Inject the following JS script into the webpage.'
       >
         <textarea id="webpage-inject-js" value={settings.injectedJS} onChange={e => updateSettings({...settings, injectedJS: e.target.value})} placeholder="Type JS"></textarea>
+      </SettingBlock>
+
+      <SettingBlock
+        titleForId='webpage-user-agent'
+        title='User Agent'
+        moreInfo='Set the following User Agent string for the webpage.'
+      >
+        <input id="webpage-user-agent" type="text" value={settings.userAgent} onChange={e => updateSettings({...settings, userAgent: e.target.value})} placeholder="Type a User Agent string" />
       </SettingBlock>
     </>
   )

--- a/src/renderer/widgets/webpage/settings.tsx
+++ b/src/renderer/widgets/webpage/settings.tsx
@@ -40,6 +40,8 @@ export interface Settings {
   sessionPersist: SettingsSessionPersist;
   sessionScope: SettingsSessionScope;
   url: string;
+  injectedCSS: string;
+  injectedJS: string;
 }
 
 export const createSettingsState: CreateSettingsState<Settings> = (settings) => ({
@@ -47,6 +49,8 @@ export const createSettingsState: CreateSettingsState<Settings> = (settings) => 
   sessionPersist: isSettingsSessionPersist(settings.sessionPersist) ? settings.sessionPersist : 'persist',
   sessionScope: isSettingsSessionScope(settings.sessionScope) ? settings.sessionScope : 'prj',
   url: typeof settings.url === 'string' ? settings.url : '',
+  injectedCSS: typeof settings.injectedCSS === 'string' ? settings.injectedCSS : '',
+  injectedJS: typeof settings.injectedJS === 'string' ? settings.injectedJS : '',
 })
 
 const debounceUpdate3s = debounce((fn: () => void) => fn(), 3000);
@@ -131,6 +135,22 @@ export function SettingsEditorComp({settings, settingsApi}: SettingsEditorReactC
           <option value="600">10 Minutes</option>
           <option value="3600">60 Minutes</option>
         </select>
+      </SettingBlock>
+
+      <SettingBlock
+        titleForId='webpage-inject-css'
+        title='Inject CSS'
+        moreInfo='Inject the following CSS style into the webpage.'
+      >
+        <textarea id="webpage-inject-css" value={settings.injectedCSS} onChange={e => updateSettings({...settings, injectedCSS: e.target.value})} placeholder="Type CSS"></textarea>
+      </SettingBlock>
+
+      <SettingBlock
+        titleForId='webpage-inject-js'
+        title='Inject JS'
+        moreInfo='Inject the following JS script into the webpage.'
+      >
+        <textarea id="webpage-inject-js" value={settings.injectedJS} onChange={e => updateSettings({...settings, injectedJS: e.target.value})} placeholder="Type JS"></textarea>
       </SettingBlock>
     </>
   )

--- a/src/renderer/widgets/webpage/widget.tsx
+++ b/src/renderer/widgets/webpage/widget.tsx
@@ -24,7 +24,7 @@ interface WebviewProps extends WidgetReactComponentProps<Settings> {
 }
 
 function Webview({settings, widgetApi, onRequireRestart, env, id}: WebviewProps) {
-  const {url, sessionScope, sessionPersist, autoReload} = settings;
+  const {url, sessionScope, sessionPersist, autoReload, injectedCSS, injectedJS} = settings;
 
   const partition = useMemo(() => createPartition(sessionPersist, sessionScope, env, id), [
     env, id, sessionScope, sessionPersist
@@ -131,6 +131,8 @@ function Webview({settings, widgetApi, onRequireRestart, env, id}: WebviewProps)
     const handleDomReady = () => {
       setWebviewIsReady(true);
       refreshActions();
+      injectedCSS && webviewEl.insertCSS(injectedCSS);
+      injectedJS && webviewEl.executeJavaScript(injectedJS);
       // webviewEl.classList.add('is-bg-visible');
     }
     const handleDidFinishLoad = () => {

--- a/src/renderer/widgets/webpage/widget.tsx
+++ b/src/renderer/widgets/webpage/widget.tsx
@@ -24,7 +24,7 @@ interface WebviewProps extends WidgetReactComponentProps<Settings> {
 }
 
 function Webview({settings, widgetApi, onRequireRestart, env, id}: WebviewProps) {
-  const {url, sessionScope, sessionPersist, autoReload, injectedCSS, injectedJS} = settings;
+  const {url, sessionScope, sessionPersist, autoReload, injectedCSS, injectedJS, userAgent} = settings;
 
   const partition = useMemo(() => createPartition(sessionPersist, sessionScope, env, id), [
     env, id, sessionScope, sessionPersist
@@ -182,6 +182,7 @@ function Webview({settings, widgetApi, onRequireRestart, env, id}: WebviewProps)
       className={styles['webview']}
       tabIndex={0} // this enables the tab-navigation to widget action bar
       src={sanitUrl}
+      useragent={userAgent}
     ></webview>
     {isLoading && <div className={styles['loading']}>Loading...</div>}
   </>


### PR DESCRIPTION
This PR adds two new fields to webpage's settings: inject CSS & JS code on DOM ready. Fixes #28.

![Freeter webpage settings](https://github.com/user-attachments/assets/f5a05592-00a8-4f6d-8a26-8e8e9b475532)

EDIT: Now you can also add a custom User Agent string!
