### PR TITLE
Add Markdown to notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "svg-sprite-loader": "^6.0.11",
     "svgo-loader": "^4.0.0",
     "swc-loader": "^0.2.6",
+    "tiny-markdown-editor": "^0.1.31",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "type-fest": "^4.20.1",
     "typescript": "^5.5.2",

--- a/src/renderer/widgets/note/settings.tsx
+++ b/src/renderer/widgets/note/settings.tsx
@@ -7,10 +7,12 @@ import { CreateSettingsState, ReactComponent, SettingBlock, SettingsEditorReactC
 
 export interface Settings {
   spellCheck: boolean;
+  markdown: boolean;
 }
 
 export const createSettingsState: CreateSettingsState<Settings> = (settings) => ({
   spellCheck: typeof settings.spellCheck === 'boolean' ? settings.spellCheck : false,
+  markdown: typeof settings.markdown === 'boolean' ? settings.markdown : false,
 })
 
 function SettingsEditorComp({settings, settingsApi}: SettingsEditorReactComponentProps<Settings>) {
@@ -28,6 +30,21 @@ function SettingsEditorComp({settings, settingsApi}: SettingsEditorReactComponen
               spellCheck: !settings.spellCheck
             })}/>
             Enable spell checking
+          </label>
+        </div>
+      </SettingBlock>
+
+      <SettingBlock
+        titleForId='markdown'
+        title='Markdown'
+      >
+        <div>
+          <label>
+            <input type="checkbox" id="markdown" checked={settings.markdown} onChange={_=>updateSettings({
+              ...settings,
+              markdown: !settings.markdown
+            })}/>
+            Enable Markdown
           </label>
         </div>
       </SettingBlock>

--- a/src/renderer/widgets/note/widget.tsx
+++ b/src/renderer/widgets/note/widget.tsx
@@ -10,6 +10,8 @@ import { Settings } from './settings';
 import { ChangeEventHandler, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createContextMenuFactory, textAreaContextId } from '@/widgets/note/contextMenu';
 import { createActionBarItems } from '@/widgets/note/actionBar';
+import { Editor } from 'tiny-markdown-editor';
+import 'tiny-markdown-editor/dist/tiny-mde.min.css';
 
 const keyNote = 'note';
 
@@ -41,6 +43,14 @@ function WidgetComp({widgetApi, settings}: WidgetReactComponentProps<Settings>) 
   useEffect(() => {
     loadNote();
   }, [loadNote])
+
+  useEffect(() => {
+    if (settings.markdown && textAreaRef.current) {
+      const tinyMDE = new Editor({textarea: textAreaRef.current});
+      tinyMDE.addEventListener('change', (e) => saveNote(e.content));
+      (textAreaRef.current.nextSibling as HTMLElement).spellcheck = settings.spellCheck;
+    }
+  })
 
   return (
     isLoaded


### PR DESCRIPTION
I've added optional Markdown support for notes using [TinyMDE](https://github.com/jefago/tiny-markdown-editor). Fixes #27.

![Freeter Markdown notes](https://github.com/user-attachments/assets/c4de25cf-4666-4bfd-a100-b040ddbad4c9)