### PR TITLE
Terminal emulator widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev:preload": "cross-env NODE_ENV=development webpack --config webpack.preload.config.js",
     "dev:renderer": "cross-env NODE_ENV=development webpack-dev-server --config webpack.renderer.config.js",
     "dev:main": "cross-env NODE_ENV=development webpack --watch --config webpack.main.config.js",
-    "dev:run": "cross-env NODE_ENV=development nodemon --on-change-only --watch build/main.js --exec \"sleep 3 && electron ./build/main.js\"",
+    "dev:run": "cross-env NODE_ENV=development nodemon --on-change-only --watch build/main.js --exec \"sleep 3 && electron --gtk-version=3 ./build/main.js\"",
     "prod": "rimraf build && yarn run prod:assets && concurrently --names \"RENDERER,MAIN,PRELOAD\" -c \"blue.bold,magenta.bold,green.bold\" \"yarn run prod:renderer\" \"yarn run prod:main\" \"yarn run prod:preload\"",
     "prod:assets": "copyfiles --up 1 src/assets/**/* build/",
     "prod:preload": "cross-env NODE_ENV=production webpack --config webpack.preload.config.js",
@@ -95,7 +95,11 @@
     "webpack-dev-server": "^5.0.4"
   },
   "dependencies": {
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "clsx": "^2.1.1",
+    "node-pty": "^1.0.0",
+    "react-xtermjs": "^1.0.10",
     "uuid": "^10.0.0",
     "zustand": "^4.5.4"
   }

--- a/src/common/ipc/channels.ts
+++ b/src/common/ipc/channels.ts
@@ -127,3 +127,22 @@ export type IpcShowBrowserWindowRes = void;
 export const ipcExecCmdLinesInTerminalChannel = makeIpcChannelName('exec-cmd-lines-in-terminal');
 export type IpcExecCmdLinesInTerminalArgs = [cmdLines: ReadonlyArray<string>, cwd?: string];
 export type IpcExecCmdLinesInTerminalRes = void;
+
+export const ipcTerminalPtyCreateChannel = makeIpcChannelName('terminal-pty-create');
+export type IpcTerminalPtyCreateArgs = [cols: number, rows: number, cwd?: string];
+export type IpcTerminalPtyCreateRes = string;
+
+export const ipcTerminalPtyWriteChannel = makeIpcChannelName('terminal-pty-write');
+export type IpcTerminalPtyWriteArgs = [sessionId: string, data: string];
+export type IpcTerminalPtyWriteRes = void;
+
+export const ipcTerminalPtyResizeChannel = makeIpcChannelName('terminal-pty-resize');
+export type IpcTerminalPtyResizeArgs = [sessionId: string, cols: number, rows: number];
+export type IpcTerminalPtyResizeRes = void;
+
+export const ipcTerminalPtyCloseChannel = makeIpcChannelName('terminal-pty-close');
+export type IpcTerminalPtyCloseArgs = [sessionId: string];
+export type IpcTerminalPtyCloseRes = void;
+
+export const ipcTerminalPtyDataChannel = makeIpcChannelName('terminal-pty-data');
+export type IpcTerminalPtyDataArgs = [sessionId: string, data: string];

--- a/src/main/controllers/terminalPty.ts
+++ b/src/main/controllers/terminalPty.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright: (c) 2024, Alex Kaul
+ * GNU General Public License v3.0 or later (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+ */
+
+import { Controller } from '@/controllers/controller';
+import { TerminalPtyManager } from '@/infra/terminalPty/terminalPtyManager';
+import {
+  ipcTerminalPtyCreateChannel,
+  IpcTerminalPtyCreateArgs,
+  IpcTerminalPtyCreateRes,
+  ipcTerminalPtyWriteChannel,
+  IpcTerminalPtyWriteArgs,
+  IpcTerminalPtyWriteRes,
+  ipcTerminalPtyResizeChannel,
+  IpcTerminalPtyResizeArgs,
+  IpcTerminalPtyResizeRes,
+  ipcTerminalPtyCloseChannel,
+  IpcTerminalPtyCloseArgs,
+  IpcTerminalPtyCloseRes,
+} from '@common/ipc/channels';
+
+type Deps = {
+  terminalPtyManager: TerminalPtyManager;
+};
+
+export function createTerminalPtyControllers({ terminalPtyManager }: Deps): [
+  Controller<IpcTerminalPtyCreateArgs, IpcTerminalPtyCreateRes>,
+  Controller<IpcTerminalPtyWriteArgs, IpcTerminalPtyWriteRes>,
+  Controller<IpcTerminalPtyResizeArgs, IpcTerminalPtyResizeRes>,
+  Controller<IpcTerminalPtyCloseArgs, IpcTerminalPtyCloseRes>,
+] {
+  return [
+    {
+      channel: ipcTerminalPtyCreateChannel,
+      handle: async (event, cols, rows, cwd) =>
+        terminalPtyManager.createSession(event, cols, rows, cwd),
+    },
+    {
+      channel: ipcTerminalPtyWriteChannel,
+      handle: async (_event, sessionId, data) => {
+        terminalPtyManager.write(sessionId, data);
+      },
+    },
+    {
+      channel: ipcTerminalPtyResizeChannel,
+      handle: async (_event, sessionId, cols, rows) => {
+        terminalPtyManager.resize(sessionId, cols, rows);
+      },
+    },
+    {
+      channel: ipcTerminalPtyCloseChannel,
+      handle: async (_event, sessionId) => {
+        terminalPtyManager.close(sessionId);
+      },
+    },
+  ];
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -69,6 +69,8 @@ import { createChildProcessProvider } from '@/infra/childProcessProvider/childPr
 import { createOpenPathUseCase } from '@/application/useCases/shell/openPath';
 import { createCopyWidgetDataStorageUseCase } from '@/application/useCases/widgetDataStorage/copyWidgetDataStorage';
 import { createOpenAppUseCase } from '@/application/useCases/shell/openApp';
+import { createTerminalPtyControllers } from '@/controllers/terminalPty';
+import { TerminalPtyManager } from '@/infra/terminalPty/terminalPtyManager';
 
 let appWindow: BrowserWindow | null = null; // ref to the app window
 
@@ -176,6 +178,7 @@ if (!app.requestSingleInstanceLock()) {
     const execCmdLinesInTerminalUseCase = createExecCmdLinesInTerminalUseCase({ appsProvider, childProcessProvider, processProvider })
 
     const openAppUseCase = createOpenAppUseCase({ childProcessProvider, processProvider })
+    const terminalPtyManager = new TerminalPtyManager();
 
     registerControllers(ipcMain, [
       ...createAppDataStorageControllers({ getTextFromAppDataStorageUseCase, setTextInAppDataStorageUseCase }),
@@ -201,7 +204,8 @@ if (!app.requestSingleInstanceLock()) {
       ...createGlobalShortcutControllers({ setMainShortcutUseCase }),
       ...createTrayMenuControllers({ setTrayMenuUseCase }),
       ...createBrowserWindowControllers({ showBrowserWindowUseCase }),
-      ...createTerminalControllers({ execCmdLinesInTerminalUseCase })
+      ...createTerminalControllers({ execCmdLinesInTerminalUseCase }),
+      ...createTerminalPtyControllers({ terminalPtyManager })
     ])
 
     const [windowStore] = createWindowStore({

--- a/src/main/infra/terminalPty/terminalPtyManager.ts
+++ b/src/main/infra/terminalPty/terminalPtyManager.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright: (c) 2024, Alex Kaul
+ * GNU General Public License v3.0 or later (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+ */
+
+import os from 'node:os';
+import { IpcMainEvent } from '@/controllers/interfaces/ipcMain';
+import { WebContents } from '@/application/interfaces/webContents';
+import { ipcTerminalPtyDataChannel } from '@common/ipc/channels';
+import type { IPty } from 'node-pty';
+import { spawn } from 'node-pty';
+
+type PtySession = {
+  pty: IPty;
+  sender: WebContents;
+};
+
+function getDefaultShell(): string {
+  if (process.platform === 'win32') {
+    return process.env.ComSpec || 'cmd.exe';
+  }
+  return process.env.SHELL || '/bin/bash';
+}
+
+let nextSessionId = 1;
+
+export class TerminalPtyManager {
+  private readonly sessions = new Map<string, PtySession>();
+
+  createSession(event: IpcMainEvent, cols: number, rows: number, cwd?: string): string {
+    const sessionId = `pty-${nextSessionId++}`;
+    const pty = spawn(getDefaultShell(), [], {
+      name: 'xterm-color',
+      cols,
+      rows,
+      cwd: cwd || os.homedir(),
+      env: process.env as Record<string, string>,
+    });
+
+    const sender = event.sender;
+    pty.onData((data) => {
+      sender.send(ipcTerminalPtyDataChannel, sessionId, data);
+    });
+    pty.onExit(() => {
+      this.sessions.delete(sessionId);
+    });
+
+    this.sessions.set(sessionId, { pty, sender });
+    return sessionId;
+  }
+
+  write(sessionId: string, data: string): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      return;
+    }
+    session.pty.write(data);
+  }
+
+  resize(sessionId: string, cols: number, rows: number): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      return;
+    }
+    session.pty.resize(cols, rows);
+  }
+
+  close(sessionId: string): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      return;
+    }
+    session.pty.kill();
+    this.sessions.delete(sessionId);
+  }
+}

--- a/src/renderer/base/state/ui.ts
+++ b/src/renderer/base/state/ui.ts
@@ -282,7 +282,7 @@ export function createUiState(): UiState {
       order: []
     },
     palette: {
-      widgetTypeIds: ['commander', 'file-opener', 'link-opener', 'note', 'timer', 'to-do-list', 'web-query', 'webpage']
+      widgetTypeIds: ['commander', 'file-opener', 'link-opener', 'note', 'terminal', 'timer', 'to-do-list', 'web-query', 'webpage']
     },
     projectSwitcher: {
       currentProjectId: '',

--- a/src/renderer/infra/terminalPty/terminalPtyClient.ts
+++ b/src/renderer/infra/terminalPty/terminalPtyClient.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright: (c) 2024, Alex Kaul
+ * GNU General Public License v3.0 or later (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+ */
+
+import {
+  ipcTerminalPtyCreateChannel,
+  IpcTerminalPtyCreateArgs,
+  IpcTerminalPtyCreateRes,
+  ipcTerminalPtyWriteChannel,
+  IpcTerminalPtyWriteArgs,
+  IpcTerminalPtyWriteRes,
+  ipcTerminalPtyResizeChannel,
+  IpcTerminalPtyResizeArgs,
+  IpcTerminalPtyResizeRes,
+  ipcTerminalPtyCloseChannel,
+  IpcTerminalPtyCloseArgs,
+  IpcTerminalPtyCloseRes,
+  ipcTerminalPtyDataChannel,
+  IpcTerminalPtyDataArgs,
+} from '@common/ipc/channels';
+import { electronIpcRenderer } from '@/infra/mainApi/mainApi';
+
+type PtyDataHandler = (data: string) => void;
+
+const handlersBySession = new Map<string, Set<PtyDataHandler>>();
+let isListenerBound = false;
+
+function ensureDataListener() {
+  if (isListenerBound) {
+    return;
+  }
+  isListenerBound = true;
+  electronIpcRenderer.on<IpcTerminalPtyDataArgs>(ipcTerminalPtyDataChannel, (sessionId, data) => {
+    const handlers = handlersBySession.get(sessionId);
+    if (!handlers) {
+      return;
+    }
+    handlers.forEach(handler => handler(data));
+  });
+}
+
+export function onTerminalPtyData(sessionId: string, handler: PtyDataHandler): () => void {
+  ensureDataListener();
+  let handlers = handlersBySession.get(sessionId);
+  if (!handlers) {
+    handlers = new Set<PtyDataHandler>();
+    handlersBySession.set(sessionId, handlers);
+  }
+  handlers.add(handler);
+
+  return () => {
+    const current = handlersBySession.get(sessionId);
+    if (!current) {
+      return;
+    }
+    current.delete(handler);
+    if (current.size === 0) {
+      handlersBySession.delete(sessionId);
+    }
+  };
+}
+
+export async function createTerminalPtySession(cols: number, rows: number, cwd?: string): Promise<string> {
+  ensureDataListener();
+  return electronIpcRenderer.invoke<IpcTerminalPtyCreateArgs, IpcTerminalPtyCreateRes>(
+    ipcTerminalPtyCreateChannel,
+    cols,
+    rows,
+    cwd
+  );
+}
+
+export async function writeTerminalPty(sessionId: string, data: string): Promise<void> {
+  return electronIpcRenderer.invoke<IpcTerminalPtyWriteArgs, IpcTerminalPtyWriteRes>(
+    ipcTerminalPtyWriteChannel,
+    sessionId,
+    data
+  );
+}
+
+export async function resizeTerminalPty(sessionId: string, cols: number, rows: number): Promise<void> {
+  return electronIpcRenderer.invoke<IpcTerminalPtyResizeArgs, IpcTerminalPtyResizeRes>(
+    ipcTerminalPtyResizeChannel,
+    sessionId,
+    cols,
+    rows
+  );
+}
+
+export async function closeTerminalPty(sessionId: string): Promise<void> {
+  return electronIpcRenderer.invoke<IpcTerminalPtyCloseArgs, IpcTerminalPtyCloseRes>(
+    ipcTerminalPtyCloseChannel,
+    sessionId
+  );
+}

--- a/src/renderer/widgets/index.ts
+++ b/src/renderer/widgets/index.ts
@@ -8,6 +8,7 @@ import commander from './commander';
 import fileOpener from './file-opener';
 import linkOpener from './link-opener';
 import note from './note';
+import terminal from './terminal';
 import timer from './timer';
 import toDoList from './to-do-list';
 import webpage from './webpage';
@@ -18,6 +19,7 @@ const widgetTypes = [
   fileOpener,
   linkOpener,
   note,
+  terminal,
   timer,
   toDoList,
   webpage,

--- a/src/renderer/widgets/terminal/icons/index.ts
+++ b/src/renderer/widgets/terminal/icons/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright: (c) 2024, Alex Kaul
+ * GNU General Public License v3.0 or later (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+ */
+
+import widgetSvg from './widget.svg';
+
+export {
+  widgetSvg
+};

--- a/src/renderer/widgets/terminal/icons/widget.svg
+++ b/src/renderer/widgets/terminal/icons/widget.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <rect x="6" y="10" width="52" height="44" rx="6" stroke="currentColor" stroke-width="4"/>
+  <path d="M18 24l10 8-10 8" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M34 40h12" stroke="currentColor" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/src/renderer/widgets/terminal/index.ts
+++ b/src/renderer/widgets/terminal/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright: (c) 2024, Alex Kaul
+ * GNU General Public License v3.0 or later (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+ */
+
+import { WidgetType } from '@/widgets/appModules';
+import { settingsEditorComp, Settings, createSettingsState } from './settings';
+import { widgetComp } from './widget';
+import { widgetSvg } from './icons';
+
+const widgetType: WidgetType<Settings> = {
+  id: 'terminal',
+  icon: widgetSvg,
+  name: 'Terminal',
+  minSize: {
+    w: 2,
+    h: 2
+  },
+  description: 'The Terminal widget lets you run a local shell directly inside Freeter.',
+  maximizable: true,
+  createSettingsState,
+  settingsEditorComp,
+  widgetComp,
+  requiresApi: ['clipboard']
+};
+
+export default widgetType;

--- a/src/renderer/widgets/terminal/settings.tsx
+++ b/src/renderer/widgets/terminal/settings.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright: (c) 2024, Alex Kaul
+ * GNU General Public License v3.0 or later (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+ */
+
+import { CreateSettingsState, ReactComponent, SettingsEditorReactComponentProps, SettingBlock } from '@/widgets/appModules';
+
+export interface Settings {
+  fontFamily: string;
+  fontSize: number;
+  cursorStyle: 'block' | 'underline' | 'bar';
+  theme: 'light' | 'dark';
+  initialCommand: string;
+}
+
+const cursorStyles: Settings['cursorStyle'][] = ['block', 'underline', 'bar'];
+const themes: Settings['theme'][] = ['light', 'dark'];
+const defaultSettings: Settings = {
+  fontFamily: 'monospace',
+  fontSize: 14,
+  cursorStyle: 'block',
+  theme: 'light',
+  initialCommand: ''
+};
+
+function isCursorStyle(value: unknown): value is Settings['cursorStyle'] {
+  return cursorStyles.includes(value as Settings['cursorStyle']);
+}
+
+function isTheme(value: unknown): value is Settings['theme'] {
+  return themes.includes(value as Settings['theme']);
+}
+
+export const createSettingsState: CreateSettingsState<Settings> = (settings) => ({
+  fontFamily: typeof settings.fontFamily === 'string' && settings.fontFamily.trim() !== ''
+    ? settings.fontFamily
+    : defaultSettings.fontFamily,
+  fontSize: typeof settings.fontSize === 'number' && Number.isFinite(settings.fontSize) && settings.fontSize > 0
+    ? Math.round(settings.fontSize)
+    : defaultSettings.fontSize,
+  cursorStyle: isCursorStyle(settings.cursorStyle) ? settings.cursorStyle : defaultSettings.cursorStyle,
+  theme: isTheme(settings.theme) ? settings.theme : defaultSettings.theme,
+  initialCommand: typeof settings.initialCommand === 'string' ? settings.initialCommand : defaultSettings.initialCommand
+});
+
+function SettingsEditorComp({ settings, settingsApi }: SettingsEditorReactComponentProps<Settings>) {
+  const { updateSettings } = settingsApi;
+
+  return (
+    <>
+      <SettingBlock
+        titleForId='terminal-font-family'
+        title='Font Family'
+        moreInfo='Font family used by the terminal text.'
+      >
+        <input
+          id='terminal-font-family'
+          type='text'
+          value={settings.fontFamily}
+          maxLength={100}
+          onChange={(e) => updateSettings({
+            ...settings,
+            fontFamily: e.target.value
+          })}
+          placeholder='monospace'
+        />
+      </SettingBlock>
+      <SettingBlock
+        titleForId='terminal-font-size'
+        title='Font Size'
+        moreInfo='Font size in pixels.'
+      >
+        <input
+          id='terminal-font-size'
+          type='number'
+          min={8}
+          max={48}
+          value={settings.fontSize}
+          onChange={(e) => {
+            const parsed = Number.parseInt(e.target.value, 10);
+            updateSettings({
+              ...settings,
+              fontSize: Number.isNaN(parsed) ? defaultSettings.fontSize : parsed
+            });
+          }}
+        />
+      </SettingBlock>
+      <SettingBlock
+        titleForId='terminal-cursor-style'
+        title='Cursor Style'
+        moreInfo='Choose how the cursor is rendered.'
+      >
+        <select
+          id='terminal-cursor-style'
+          value={settings.cursorStyle}
+          onChange={(e) => updateSettings({
+            ...settings,
+            cursorStyle: isCursorStyle(e.target.value) ? e.target.value : defaultSettings.cursorStyle
+          })}
+        >
+          <option value='block'>Block</option>
+          <option value='underline'>Underline</option>
+          <option value='bar'>Bar</option>
+        </select>
+      </SettingBlock>
+      <SettingBlock
+        titleForId='terminal-theme'
+        title='Theme'
+        moreInfo='Pick a terminal theme.'
+      >
+        <select
+          id='terminal-theme'
+          value={settings.theme}
+          onChange={(e) => updateSettings({
+            ...settings,
+            theme: isTheme(e.target.value) ? e.target.value : defaultSettings.theme
+          })}
+        >
+          <option value='light'>Light</option>
+          <option value='dark'>Dark</option>
+        </select>
+      </SettingBlock>
+      <SettingBlock
+        titleForId='terminal-initial-command'
+        title='Initial Command'
+        moreInfo='Command to run once when the terminal session starts.'
+      >
+        <textarea
+          id='terminal-initial-command'
+          value={settings.initialCommand}
+          rows={3}
+          onChange={(e) => updateSettings({
+            ...settings,
+            initialCommand: e.target.value
+          })}
+          placeholder='Optional command to run'
+        />
+      </SettingBlock>
+    </>
+  );
+}
+
+export const settingsEditorComp: ReactComponent<SettingsEditorReactComponentProps<Settings>> = {
+  type: 'react',
+  Comp: SettingsEditorComp
+};

--- a/src/renderer/widgets/terminal/widget.module.scss
+++ b/src/renderer/widgets/terminal/widget.module.scss
@@ -1,0 +1,17 @@
+.terminal-root {
+  width: 100%;
+  height: 100%;
+  display: flex;
+}
+
+.terminal-container {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  user-select: text;
+}
+
+.terminal-container :global(.xterm),
+.terminal-container :global(.xterm *) {
+  user-select: text;
+}

--- a/src/renderer/widgets/terminal/widget.tsx
+++ b/src/renderer/widgets/terminal/widget.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright: (c) 2024, Alex Kaul
+ * GNU General Public License v3.0 or later (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+ */
+
+import '@xterm/xterm/css/xterm.css';
+import { ReactComponent, WidgetReactComponentProps } from '@/widgets/appModules';
+import { useEffect, useMemo, useRef } from 'react';
+import { useXTerm } from 'react-xtermjs';
+import { FitAddon } from '@xterm/addon-fit';
+import { Settings } from './settings';
+import * as styles from './widget.module.scss';
+import { closeTerminalPty, createTerminalPtySession, onTerminalPtyData, resizeTerminalPty, writeTerminalPty } from '@/infra/terminalPty/terminalPtyClient';
+
+function WidgetComp({ widgetApi, settings }: WidgetReactComponentProps<Settings>) {
+  const xtermTheme = useMemo(() => {
+    const isDark = settings.theme === 'dark';
+    return {
+      background: isDark ? '#1e1e1e' : '#f8f8f8',
+      foreground: isDark ? '#f8f8f8' : '#000000',
+      cursor: isDark ? '#f8f8f8' : '#000000',
+      selectionBackground: isDark ? '#f8f8f8' : '#000000',
+      selectionForeground: isDark ? '#000000' : '#ffffff'
+    };
+  }, [settings.theme]);
+  const fitAddon = useMemo(() => new FitAddon(), []);
+  const { instance, ref } = useXTerm();
+  const sessionIdRef = useRef<string | null>(null);
+  const disposeDataRef = useRef<(() => void) | null>(null);
+  const disposeInputRef = useRef<{ dispose: () => void } | null>(null);
+  const initialCommandRef = useRef(settings.initialCommand);
+
+  useEffect(() => {
+    initialCommandRef.current = settings.initialCommand;
+  }, [settings.initialCommand]);
+
+  useEffect(() => {
+    if (!instance) {
+      return () => undefined;
+    }
+    instance.options.fontFamily = settings.fontFamily;
+    instance.options.fontSize = settings.fontSize;
+    instance.options.cursorStyle = settings.cursorStyle;
+    instance.options.theme = xtermTheme;
+    return () => undefined;
+  }, [instance, settings.cursorStyle, settings.fontFamily, settings.fontSize, xtermTheme]);
+
+  useEffect(() => {
+    if (!instance) {
+      return () => undefined;
+    }
+
+    instance.attachCustomKeyEventHandler((event) => {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'c') {
+        const selection = instance.getSelection();
+        if (selection) {
+          void widgetApi.clipboard.writeText(selection);
+          return false;
+        }
+      }
+      return true;
+    });
+
+    instance.loadAddon(fitAddon);
+    const container = ref.current;
+    if (container) {
+      requestAnimationFrame(() => {
+        fitAddon.fit();
+      });
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      fitAddon.fit();
+      if (sessionIdRef.current) {
+        void resizeTerminalPty(sessionIdRef.current, instance.cols, instance.rows);
+      }
+    });
+    if (container) {
+      resizeObserver.observe(container);
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [fitAddon, instance, ref, widgetApi.clipboard]);
+
+  useEffect(() => {
+    if (!instance) {
+      return () => undefined;
+    }
+
+    let disposed = false;
+    void (async () => {
+      fitAddon.fit();
+      const sessionId = await createTerminalPtySession(instance.cols, instance.rows);
+      if (disposed) {
+        await closeTerminalPty(sessionId);
+        return;
+      }
+      sessionIdRef.current = sessionId;
+      const initialCommand = initialCommandRef.current.trim();
+      if (initialCommand !== '') {
+        void writeTerminalPty(sessionId, `${initialCommand}\n`);
+      }
+      disposeDataRef.current = onTerminalPtyData(sessionId, (data) => {
+        instance.write(data);
+      });
+      disposeInputRef.current = instance.onData((data) => {
+        if (sessionIdRef.current) {
+          void writeTerminalPty(sessionIdRef.current, data);
+        }
+      });
+    })();
+
+    return () => {
+      disposed = true;
+      disposeDataRef.current?.();
+      disposeDataRef.current = null;
+      disposeInputRef.current?.dispose();
+      disposeInputRef.current = null;
+      if (sessionIdRef.current) {
+        void closeTerminalPty(sessionIdRef.current);
+        sessionIdRef.current = null;
+      }
+    };
+  }, [fitAddon, instance]);
+
+  return (
+    <div className={styles['terminal-root']}>
+      <div ref={ref} className={styles['terminal-container']} />
+    </div>
+  );
+}
+
+export const widgetComp: ReactComponent<WidgetReactComponentProps<Settings>> = {
+  type: 'react',
+  Comp: WidgetComp
+};

--- a/webpack.main.config.js
+++ b/webpack.main.config.js
@@ -30,6 +30,9 @@ module.exports = {
     })]
   },
   target: 'electron-main',
+  externals: {
+    'node-pty': 'commonjs2 node-pty',
+  },
   module: {
     rules: [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1726,6 +1726,16 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
+"@xterm/addon-fit@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-fit/-/addon-fit-0.10.0.tgz#bebf87fadd74e3af30fdcdeef47030e2592c6f55"
+  integrity sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==
+
+"@xterm/xterm@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-5.5.0.tgz#275fb8f6e14afa6e8a0c05d4ebc94523ff775396"
+  integrity sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -6842,6 +6852,11 @@ node-addon-api@^1.6.3:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
+node-addon-api@^7.1.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
+  integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
+
 node-api-version@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/node-api-version/-/node-api-version-0.2.1.tgz#19bad54f6d65628cbee4e607a325e4488ace2de9"
@@ -6858,6 +6873,13 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
+
+node-pty@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-1.1.0.tgz#161936d45a47751c2e3b694c365e73017417a887"
+  integrity sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==
+  dependencies:
+    node-addon-api "^7.1.0"
 
 node-releases@^2.0.14, node-releases@^2.0.19:
   version "2.0.19"
@@ -7681,6 +7703,11 @@ react-is@^18.0.0:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+react-xtermjs@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/react-xtermjs/-/react-xtermjs-1.0.10.tgz#faac189f60ca599345b69b5c1a6b662f537df667"
+  integrity sha512-+xpKEKbmsypWzRKE0FR1LNIGcI8gx+R6VMHe8IQW7iTbgeqp3Qg7SbiVNOzR+Ovb1QK4DPA3KqsIQV+XP0iRUA==
 
 react@^19.1.0:
   version "19.1.0"
@@ -8586,7 +8613,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8602,6 +8629,15 @@ string-width@^2.0.0, string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -8690,7 +8726,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8710,6 +8746,13 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -9770,7 +9813,16 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
<img width="500" alt="image" src="https://github.com/user-attachments/assets/8000882d-ab8c-4d3f-b5da-753b5b8ff344" />

<img width="200" alt="image" src="https://github.com/user-attachments/assets/1b850cbc-eb81-45c2-9e5b-ad3e6cd1f8cc" />


A inline terminal widget with some simple configurations.

- Tested on Ubuntu 22.04
- This PR is completely written by LLM, I didn't check how "correct" is the approach, but the code seems to work well.
- I submitted this PR with the expectation of it may never be merged, but people who need it can use / work on my fork instead.
- I can't find an icon for the terminal widget that fit with the style of the other icons, did you hand draw these icons?
