### PR TITLE
Harden shell command escaping and fix data storage bug

### DIFF
--- a/src/main/base/apps/terminal.ts
+++ b/src/main/base/apps/terminal.ts
@@ -3,7 +3,7 @@
  * GNU General Public License v3.0 or later (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
  */
 
-const escBackslashesDblQuotes = (str: string) => str.replace(/[\\"]/g, '\\$&');
+const escBackslashesDblQuotes = (str: string) => str.replace(/[\\"$`]/g, '\\$&');
 const escBashCmdLine = escBackslashesDblQuotes;
 const escAppleScriptCmdLine = escBackslashesDblQuotes;
 

--- a/src/main/infra/dataStorage/fileDataStorage.ts
+++ b/src/main/infra/dataStorage/fileDataStorage.ts
@@ -62,7 +62,7 @@ export async function createFileDataStorage(dataType: 'string', storageDirPath: 
     deleteItem: async (key) => {
       const filePath = storageKeyToFilePath(normStorageDirPath, key);
       if (filePath) {
-        rm(filePath)
+        await rm(filePath)
       }
     },
     getText: async (key) => {
@@ -81,7 +81,7 @@ export async function createFileDataStorage(dataType: 'string', storageDirPath: 
       try {
         const filePath = storageKeyToFilePath(normStorageDirPath, key);
         if (filePath) {
-          return await writeFile(join(normStorageDirPath, key), data, { encoding: 'utf-8' })
+          return await writeFile(filePath, data, { encoding: 'utf-8' })
         } else {
           return undefined;
         }


### PR DESCRIPTION
- In `src/main/base/apps/terminal.ts`, updated `escBackslashesDblQuotes` to escape `$` and `` ` `` characters to prevent command injection in double-quoted strings.
- In `src/main/infra/dataStorage/fileDataStorage.ts`, added the missing `await` keyword to the `rm(filePath)` call in `deleteItem`.
- In `src/main/infra/dataStorage/fileDataStorage.ts`, updated `setText` to use the sanitized `filePath` variable instead of `join(normStorageDirPath, key)`.